### PR TITLE
refactor: Split permission management in its own util

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,6 @@
 		"rollup-plugin-visualizer": "^4.0.4",
 		"semantic-release": "^17.0.7"
 	},
-	"jest": {
-		"testPathIgnorePatterns": [
-			".+Mock.js"
-		]
-	},
 	"husky": {
 		"hooks": {
 			"pre-commit": "yarn test:ci && yarn prettier"

--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -1,0 +1,115 @@
+import getPermission from '../getPermission'
+
+describe('getPermission', () => {
+	describe('navigator.permissions is not implemented', () => {
+		beforeAll(() => {
+			global.navigator.permissions = undefined
+		})
+
+		it('rejects promise', async () => {
+			try {
+				await getPermission()
+			} catch (error) {
+				expect(error).toEqual(new DOMException('NOT_FOUND_ERR', 'NotFoundError'))
+			}
+		})
+	})
+
+	describe('navigator.permissions is implemented', () => {
+		const mockPermissionsQuery = jest.fn()
+
+		beforeAll(() => {
+			global.PermissionStatus = jest.fn(() => ({
+				state: 'granted',
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			}))
+			global.Permissions = jest.fn(() => ({
+				query: mockPermissionsQuery,
+			}))
+			global.navigator.permissions = new Permissions()
+		})
+
+		beforeEach(() => {
+			mockPermissionsQuery.mockReset()
+		})
+
+		afterAll(() => {
+			global.PermissionStatus.mockReset()
+			global.Permissions.mockReset()
+		})
+
+		it('rejects promise since user has previously denied permissions', async () => {
+			const status = new PermissionStatus()
+			status.state = 'denied'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			try {
+				await getPermission()
+			} catch (error) {
+				expect(error).toEqual(new DOMException('NOT_ALLOWED_ERR', 'NotAllowedError'))
+			}
+		})
+
+		it('resolves promise since user has previously granted permission', async () => {
+			const status = new PermissionStatus()
+			status.state = 'granted'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			try {
+				const status = await getPermission()
+				expect(status).toBe('granted')
+			} catch (error) {
+				throw error
+			}
+		})
+
+		it('rejects promise since user has been prompted and has denied permissions', async () => {
+			const status = new PermissionStatus()
+			status.state = 'prompt'
+			status.addEventListener = jest.fn((e, cb) => {
+				const event = {
+					target: {
+						state: 'denied',
+					},
+				}
+				cb(event)
+			})
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			try {
+				await getPermission()
+			} catch (error) {
+				expect(error).toEqual(new DOMException('NOT_ALLOWED_ERR', 'NotAllowedError'))
+			}
+		})
+
+		it('resolves promise since user has been prompted and has granted permissions', async () => {
+			const status = new PermissionStatus()
+			status.state = 'prompt'
+			status.addEventListener = jest.fn((e, cb) => {
+				const event = {
+					target: {
+						state: 'granted',
+					},
+				}
+				cb(event)
+			})
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			try {
+				const status = await getPermission()
+				expect(status).toBe('granted')
+			} catch (error) {
+				throw error
+			}
+		})
+
+		it('throws error', async () => {
+			mockPermissionsQuery.mockImplementationOnce(() => {
+				throw new Error('ERR')
+			})
+			try {
+				await getPermission()
+			} catch (error) {
+				expect(error).toEqual(new Error('ERR'))
+			}
+		})
+	})
+})

--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -1,0 +1,36 @@
+/**
+ * Returns a promise resolved when the permission is granted by the user
+ * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
+ * @returns {Promise}
+ */
+export default async (permissionName) => {
+	return new Promise(async (resolve, reject) => {
+		if (!navigator.permissions) {
+			reject(new DOMException('NOT_FOUND_ERR', 'NotFoundError'))
+		} else {
+			try {
+				const permissionStatus = await navigator.permissions.query({ name: permissionName })
+				switch (permissionStatus.state) {
+					case 'denied':
+						reject(new DOMException('NOT_ALLOWED_ERR', 'NotAllowedError'))
+						break
+					case 'prompt':
+						const onChange = event => {
+							permissionStatus.removeEventListener('change', onChange)
+							if (event.target.state === 'denied') {
+								reject(new DOMException('NOT_ALLOWED_ERR', 'NotAllowedError'))
+							} else {
+								resolve(event.target.state)
+							}
+						}
+						permissionStatus.addEventListener('change', onChange)
+						break
+					default:
+						resolve(permissionStatus.state)
+				}
+			} catch (error) {
+				reject(error)
+			}
+		}
+	})
+}

--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -1,3 +1,5 @@
+import getPermission from './getPermission'
+
 /**
  * Returns a promise resolved when the media is authorized and the stream is retrieved
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
@@ -6,33 +8,15 @@
  */
 export default async (permissionName, mediaStreamConstraints) => {
 	return new Promise(async (resolve, reject) => {
-		if (!navigator.permissions) {
-			reject(new Error('PERMISSIONS_NOT_SUPPORTED'))
+		if (!navigator.mediaDevices) {
+			reject(new DOMException('NOT_FOUND_ERR', 'NotFoundError'))
 		} else {
 			try {
-				const permissionStatus = await navigator.permissions.query({ name: permissionName })
-				if (permissionStatus.state === 'denied') {
-					reject(new Error('DENIED_BY_USER'))
-				} else if (!navigator.mediaDevices) {
-					reject(new Error('MEDIA_DEVICES_NOT_SUPPORTED'))
-				} else {
-					const promises = [await navigator.mediaDevices.getUserMedia(mediaStreamConstraints)]
-					if (permissionStatus.state === 'prompt') {
-						promises.push(
-							await new Promise((resolve) => {
-								permissionStatus.addEventListener('change', (event) => {
-									if (event.target.state === 'denied') {
-										reject(new Error('DENIED_BY_USER'))
-									} else {
-										resolve()
-									}
-								})
-							})
-						)
-					}
-					const [stream] = await Promise.all(promises)
-					resolve(stream)
-				}
+				const [, stream] = await Promise.all([
+					await getPermission(permissionName),
+					await navigator.mediaDevices.getUserMedia(mediaStreamConstraints),
+				])
+				resolve(stream)
 			} catch (error) {
 				reject(error)
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
+export { default as getPermission } from './getPermission'
 export { default as getUserMediaStream } from './getUserMediaStream'


### PR DESCRIPTION
In order to deal with more permissions-based utils, this PR extracts the permissions management in its own file.